### PR TITLE
Enable noImplicitAny

### DIFF
--- a/src/css-reset/index.tsx
+++ b/src/css-reset/index.tsx
@@ -11,7 +11,7 @@ import theme from "../theme";
 const defaultConfig = (theme: any) => ({
   light: {
     color: theme.colors.ink[900],
-    bg: undefined,
+    bg: (undefined as any),
     borderColor: theme.colors.ink[100],
     placeholderColor: theme.colors.ink[400]
   },

--- a/src/form-control/index.tsx
+++ b/src/form-control/index.tsx
@@ -6,7 +6,7 @@ const FormControlContext = createContext({});
 
 export const useFormControlContext = () => useContext(FormControlContext);
 
-export const useFormControl = props => {
+export const useFormControl = (props: any) => {
   const context = useFormControlContext();
   if (!context) {
     return props;

--- a/src/input/styles.tsx
+++ b/src/input/styles.tsx
@@ -37,7 +37,13 @@ const defaultStyle = {
   }
 };
 
-const unstyledStyle = {
+interface UnstyledStyle {
+  bg: string;
+  px?: string;
+  height?: string;
+}
+
+const unstyledStyle: UnstyledStyle = {
   bg: "transparent",
   px: undefined,
   height: undefined

--- a/src/use-clipboard/index.tsx
+++ b/src/use-clipboard/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
-interface IClipboard<T> {
-  value?: T;
+interface Clipboard {
+  value?: string;
   onCopy?: () => void;
   hasCopied?: boolean;
 }
@@ -10,7 +10,7 @@ interface IClipboard<T> {
  *
  * @param {any} value - The content to add to clipboard
  */
-const copyToClipboard = value => {
+const copyToClipboard = (value: string) => {
   const el = document.createElement("textarea");
   el.value = value;
   el.setAttribute("readonly", "");
@@ -32,7 +32,7 @@ const copyToClipboard = value => {
   }
 };
 
-function useClipboard<T>(value: T): IClipboard<T> {
+function useClipboard(value: string): Clipboard {
   const [hasCopied, setHasCopied] = useState(false);
 
   const onCopy = () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "es2017"],
     "jsx": "react",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
@@ -15,7 +15,7 @@
     "outDir": "./lib",
     "skipLibCheck": true,
     "rootDir": "./src",
-    "noImplicitAny": false, // TODO remove in the future
+    "noImplicitAny": true,
     "strictNullChecks": false // TODO remove in the future
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
Took a quick look at the `noImplicitAny` errors. For now just coerced them to explicit any's.