### PR TITLE
feature: Export all properties, including types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/ui",
   "description": "Blockstack UI components built using React and styled-components with styled-system.",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.20",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "dependencies": {
     "@styled-system/css": "5.0.23",

--- a/src/box/index.tsx
+++ b/src/box/index.tsx
@@ -39,11 +39,9 @@ export const systemProps = compose(
   colorStyle
 )
 
-const StyledBox = styled.div<BoxProps>`
+export const StyledBox = styled.div<BoxProps>`
   ${systemProps};
   ${extraConfig};
 `
 
-const Box = forwardRef((props: BoxProps, ref: Ref<HTMLDivElement>) => <StyledBox ref={ref} {...props} />)
-
-export { Box, StyledBox }
+export const Box = forwardRef((props: BoxProps, ref: Ref<HTMLDivElement>) => <StyledBox ref={ref} {...props} />)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,20 @@
-export { Box } from './box'
-export { PseudoBox } from './pseudo-box'
-export { Flex } from './flex'
-export { Grid } from './grid'
-export { Text } from './text'
-export { Button } from './button'
-export { ButtonGroup } from './button-group'
-export { CSSReset } from './css-reset'
-export { Input } from './input'
-export { InputGroup } from './input-group'
-export { InputElement, InputLeftElement, InputRightElement } from './input-element'
-export { InputAddon, InputLeftAddon, InputRightAddon } from './input-addon'
-export { FormLabel } from './form-label'
-export { FormControl } from './form-control'
-export { Spinner } from './spinner'
-export { Stack } from './stack'
-export { VisuallyHidden } from './visually-hidden'
-export { theme } from './theme'
-export { useClipboard } from './use-clipboard'
-export { ThemeProvider } from './theme-provider'
-export * from './theme-provider'
+export * from './box';
+export * from './pseudo-box';
+export * from './flex';
+export * from './grid';
+export * from './text';
+export * from './button';
+export * from './button-group';
+export * from './css-reset';
+export * from './input';
+export * from './input-group';
+export * from './input-element';
+export * from './input-addon';
+export * from './form-label';
+export * from './form-control';
+export * from './spinner';
+export * from './stack';
+export * from './visually-hidden';
+export * from './theme';
+export * from './use-clipboard';
+export * from './theme-provider';


### PR DESCRIPTION
As noticed in @hstove's PR where types are being imported from the `dist` folder, this PR exposes more properties of the UI lib, allowing use of its types.