### PR TITLE
feat: When component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export * from './visually-hidden';
 export * from './theme';
 export * from './use-clipboard';
 export * from './theme-provider';
+export * from './when';

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -38,42 +38,44 @@ const Modal: React.FC<ModalProps> = ({
   ...rest
 }) => {
   return (
+    // <Flex
+    //   position="fixed"
+    //   size="100%"
+    //   left={0}
+    //   top={0}
+    //   align={['flex-end', 'center']}
+    //   justify="center"
+    //   bg={`rgba(0,0,0,${isOpen ? '0.48' : '0'})`}
+    //   opacity={isOpen ? 1 : 0}
+    //   zIndex={9999999}
+    //   transition={noAnimation ? 'unset' : 'all 0.2s'}
+    //   style={{
+    //     userSelect: isOpen ? 'unset' : 'none',
+    //     pointerEvents: isOpen ? 'unset' : 'none',
+    //   }}
+    //   {...rest}
+    // >
     <Flex
-      position="fixed"
-      size="100%"
-      left={0}
-      top={0}
-      align={['flex-end', 'center']}
-      justify="center"
-      bg={`rgba(0,0,0,${isOpen ? '0.48' : '0'})`}
-      opacity={isOpen ? 1 : 0}
-      zIndex={9999999}
+      as="dialog"
+      p={0}
+      bg="white"
+      direction="column"
+      minWidth={['100%', '440px']}
+      width="100%"
+      maxWidth={['100%', '440px']}
+      maxHeight={['100vh', 'calc(100vh - 48px)']}
+      borderRadius={['unset', '6px']}
+      boxShadow="high"
+      transform={isOpen ? 'none' : noAnimation ? 'none' : 'translateY(10px)'}
       transition={noAnimation ? 'unset' : 'all 0.2s'}
-      style={{
-        userSelect: isOpen ? 'unset' : 'none',
-        pointerEvents: isOpen ? 'unset' : 'none',
-      }}
-      {...rest}
     >
-      <Flex
-        bg="white"
-        direction="column"
-        minWidth={['100%', '440px']}
-        width="100%"
-        maxWidth={['100%', '440px']}
-        maxHeight={['100vh', 'calc(100vh - 48px)']}
-        borderRadius={['unset', '6px']}
-        boxShadow="high"
-        transform={isOpen ? 'none' : noAnimation ? 'none' : 'translateY(10px)'}
-        transition={noAnimation ? 'unset' : 'all 0.2s'}
-      >
-        <Header component={HeaderComponent} />
-        <Flex width="100%" overflowY="auto" flexGrow={1} position="relative">
-          <ModalContent>{children}</ModalContent>
-        </Flex>
-        <Footer component={FooterComponent} />
+      <Header component={HeaderComponent} />
+      <Flex width="100%" overflowY="auto" flexGrow={1} position="relative">
+        <ModalContent>{children}</ModalContent>
       </Flex>
+      <Footer component={FooterComponent} />
     </Flex>
+    // </Flex>
   );
 };
 

--- a/src/utils/with-condition.tsx
+++ b/src/utils/with-condition.tsx
@@ -1,0 +1,9 @@
+import React, { forwardRef } from 'react';
+
+type Component = ({ ref }: any) => JSX.Element;
+
+export function withCondition(Component: Component) {
+  return ({ condition = true, forwardedRef, ...rest }) => {
+    return forwardRef((props, ref) => (!!condition ? <Component ref={forwardedRef} {...rest} /> : null));
+  };
+}

--- a/src/when/index.tsx
+++ b/src/when/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 interface WhenProps {
   // Typing as `any` allows consumers of this component to make use of truthy/falsy props
   condition: boolean | any;
+
 }
 
 export const When: React.FC<WhenProps> = ({ condition, children }) => (!!condition ? <>{children}</> : null);

--- a/src/when/index.tsx
+++ b/src/when/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+interface WhenProps {
+  // Typing as `any` allows consumers of this component to make use of truthy/falsy props
+  condition: boolean | any;
+}
+
+export const When: React.FC<WhenProps> = ({ condition, children }) => (!!condition ? <>{children}</> : null);


### PR DESCRIPTION
I propose we add a helper component like this to the UI library. 

Personally, I find it visually difficult to navigate code where there are conditional JSX statements, wrapping tens or more lines of template. A template-less component like this will go some way to tidying things up and improving readability.

Not attached to the naming, please suggest alternates.

**With helper:**
```tsx
<When condition={state.imageUrl !== ''}>
  <Box>
     ...
  </Box>
</When>
```

**Without helper:**
```tsx
{state.imageUrl === '' ? (
  undefined
) : (
  <Box>
    ...
  </Box>
)}
```

Sidenote, can't help but feel 120 chars long is too long, and that 100 would be a better compromise 😅 

**Questions**
- What readability-friendly API can we use for cases where we want to display something on the else case?