### PR TITLE
feat: Add a ChevronIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
+## 1.0.0-alpha.28
+
+- Add `ChevronIcon` component, update `Button`s to align with styleguide.
+
 ## 1.0.0-alpha.25
 
 - Add `displayName` attr to all components that use forwarRef.
-
-## 1.0.0-alpha.25
-
 - Add `textTransform` prop to base BoxProps.
 
 ## 1.0.0-alpha.24

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/ui",
   "description": "Blockstack UI components built using React and styled-components with styled-system.",
-  "version": "1.0.0-alpha.27",
+  "version": "1.0.0-alpha.28",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.org/)",
   "bundlesize": [
     {

--- a/src/icons/chevron.tsx
+++ b/src/icons/chevron.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, BoxProps } from '../box';
+
+type Direction = 'up' | 'down' | 'left' | 'right';
+
+interface ChevronProps extends BoxProps {
+  direction: Direction;
+  size: number;
+}
+
+const rotate = (direction: Direction = 'right') => {
+  switch (direction) {
+    case 'left':
+      return '90';
+    case 'up':
+      return '180';
+    case 'right':
+      return '270';
+    case 'down':
+      return 0;
+    default:
+      throw new Error('`rotate` must receive direction parameter');
+  }
+};
+
+export const ChevronIcon = ({ direction, size = 16, ...props }: ChevronProps) => (
+  <Box {...props}>
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" transform={`rotate(${rotate(direction)})`}>
+      <path fill="#C1C3CC" d="M4.7 7.367l3.3 3.3 3.3-3.3-.943-.943L8 8.78 5.643 6.424l-.943.943z"></path>
+    </svg>
+  </Box>
+);

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -1,0 +1,1 @@
+export * from './chevron';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from './input-element';
 export * from './input-addon';
 export * from './form-label';
 export * from './form-control';
+export * from './icons';
 export * from './modal';
 export * from './spinner';
 export * from './stack';


### PR DESCRIPTION
Adds a Chevron icon that's used throughout our styleguide.

I've added to changelog, although think we don't need to add quite such detail here until we're past alpha release with multiple dependents of the lib. Right now it doesn't add much more than is already in git history.