### PR TITLE
fix: Smaller font size

### DIFF
--- a/src/button/styles.tsx
+++ b/src/button/styles.tsx
@@ -20,13 +20,13 @@ const sizes = {
   lg: {
     height: 12,
     minWidth: 9 * 14,
-    fontSize: 'body.small',
+    fontSize: '14px',
     px: 5,
   },
   md: {
     height: 10,
     minWidth: 10,
-    fontSize: 'body.small',
+    fontSize: '14px',
     px: 4,
   }
 };

--- a/src/button/types.ts
+++ b/src/button/types.ts
@@ -5,7 +5,7 @@ import { PseudoBoxProps } from '../pseudo-box/types';
 /**
  * The size of the button
  */
-export type ButtonSizes = 'sm' | 'md' | 'lg';
+export type ButtonSizes = 'md' | 'lg';
 /**
  * The color scheme of the button variant. Use the color keys passed in `theme.colors`.
  */


### PR DESCRIPTION
@aulneau I haven't really changed much to the implementation of the buttons, but the string being passed to the buttons referencing the font size was rendering as a string? Should it parse this from the theme?

Changed to string for now.