### PR TITLE
refactor: Remove implicit use of 'createGlobalStyle'

### DIFF
--- a/src/css-reset/index.tsx
+++ b/src/css-reset/index.tsx
@@ -1,7 +1,6 @@
-import { createGlobalStyle } from 'styled-components';
+import styled, { createGlobalStyle, css } from 'styled-components';
 import preflight from './preflight';
-import { theme } from '../theme';
-import typography from '../theme/typography';
+import { theme } from '../theme/theme';
 
 // Should type as theme here, however this type
 // has optional properties. Need to enforce type to ensure
@@ -23,22 +22,20 @@ const defaultConfig = (theme: any) => ({
 
 const { color, bg, borderColor, placeholderColor } = defaultConfig(theme).light;
 
-const CSSReset = createGlobalStyle`
+const cssReset = css`
   ${preflight};
+
   html {
     line-height: 1.5;
     color: ${color};
     background-color: ${bg};
-    font-family: ${typography.fonts.body};
+    font-family: ${theme && theme.fonts && theme.fonts['body']};
   }
-
-  /**
-  * Allow adding a border to an element by just adding a border-width.
-  */
 
   *,
   *::before,
   *::after {
+    box-sizing: border-box;
     border-width: 0;
     border-style: solid;
     border-color: ${borderColor};
@@ -60,4 +57,30 @@ const CSSReset = createGlobalStyle`
   }
 `;
 
-export { CSSReset };
+const CSSReset = createGlobalStyle`${cssReset}`;
+
+const ScopedCSSReset = styled.div`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    border-color: ${borderColor};
+  }
+
+  input:-ms-input-placeholder,
+  textarea:-ms-input-placeholder {
+    color: ${placeholderColor};
+  }
+
+  input::-ms-input-placeholder,
+  textarea::-ms-input-placeholder {
+    color: ${placeholderColor};
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: ${placeholderColor};
+  }
+`;
+
+export { CSSReset, ScopedCSSReset };


### PR DESCRIPTION
This PR was prompted by blockstack/connect#50.

The UI library modifies global styles when used. This way cause unusual layout reflows, and add styles that aren't necessarily wanted.

We may not want to remove all this code, however I would suggest the following:

1) Ensure the addition of these styles requires opt-in by the consumer of the library
2) Reduce the amount of styles added to global scope, especially use of `*` selector

This code especially would better be encapsulated in the components themselves I reckon, even at the cost of a little bit more repetition.  
```css
*,
*::before,
*::after {
  border-width: 0;
  border-style: solid;
  border-color: ${borderColor};
}

input:-ms-input-placeholder,
textarea:-ms-input-placeholder {
  color: ${placeholderColor};
}

input::-ms-input-placeholder,
textarea::-ms-input-placeholder {
  color: ${placeholderColor};
}

input::placeholder,
textarea::placeholder {
  color: ${placeholderColor};
}
```

@aulneau Would like your feedback on best way to do this, or whether we should remove this code altogether. 