### PR TITLE
Fix/modal broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "repository": "https://github.com/blockstackpbc/blockstack-ui",
   "scripts": {
     "build": "cross-env NODE_ENV=production tsdx build --format=cjs,esm,umd",
+    "dev": "tsdx watch --format=cjs,esm,umd",
     "bundlesize": "bundlesize",
     "format": "npm run prettier -- --write",
     "lint": "eslint \"src/**/*.+(ts|tsx)\"",

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Box } from '../box';
-import { Flex } from '../flex';
+import { Flex, FlexProps } from '../flex';
 import { ModalContextTypes, ModalProps, WrapperComponentProps } from './types';
 import useOnClickOutside from 'use-onclickoutside';
-import { transition } from '../theme/theme';
 
 const ModalContext = React.createContext<ModalContextTypes>({
   isOpen: false,
@@ -39,14 +38,65 @@ const ModalUnderlay = ({ isOpen, noAnimation }: ModalUnderlayProps) => (
     top={0}
     bottom={0}
     bg={`rgba(0,0,0,${isOpen ? '0.48' : '0'})`}
-    transition={noAnimation ? 'unset' : 'all 0.2s'}
+    transition={noAnimation ? 'unset' : 'all 0.15s'}
     zIndex={99999}
     style={{
       userSelect: isOpen ? 'unset' : 'none',
       pointerEvents: isOpen ? 'unset' : 'none',
+      willChange: 'background',
     }}
   />
 );
+interface ModalWrapperProps extends FlexProps {
+  isOpen: boolean;
+}
+
+const ModalWrapper = ({ isOpen, ...rest }: ModalWrapperProps) => (
+  <Flex
+    zIndex={999999}
+    position="fixed"
+    bottom={[0, 'unset']}
+    width="100%"
+    top={0}
+    left={0}
+    height="100%"
+    maxHeight={['100vh', 'unset']}
+    alignItems="center"
+    justifyContent={['flex-end', 'center']}
+    flexDirection="column"
+    opacity={isOpen ? 1 : 0}
+    style={{
+      userSelect: isOpen ? 'unset' : 'none',
+      pointerEvents: isOpen ? 'unset' : 'none',
+    }}
+    {...rest}
+  />
+);
+
+interface ModalCardContainerProps extends FlexProps {
+  isOpen: boolean;
+  noAnimation: boolean;
+}
+const ModalCardContainer = React.forwardRef<any, ModalCardContainerProps>(({ noAnimation, isOpen, ...rest }, ref) => (
+  <Flex
+    flexDirection="column"
+    position="relative"
+    bg="white"
+    mx="auto"
+    minWidth={['100%', '396px']}
+    maxWidth={['100%', '396px']}
+    maxHeight={['100%', 'calc(100% - 48px)']}
+    borderRadius={['unset', '6px']}
+    boxShadow="high"
+    transform={noAnimation ? 'translateY(0px)' : isOpen ? 'translateY(0px)' : 'translateY(15px)'}
+    transition={noAnimation ? 'unset' : 'all 0.2s ease-in-out'}
+    style={{
+      willChange: 'transform',
+    }}
+    ref={ref}
+    {...rest}
+  />
+));
 
 export const Modal: React.FC<ModalProps> = ({
   footerComponent: FooterComponent = null,
@@ -63,38 +113,13 @@ export const Modal: React.FC<ModalProps> = ({
   return (
     <>
       <ModalUnderlay isOpen={isOpen} noAnimation={noAnimation} />
-      <Box
-        zIndex={999999}
-        position="fixed"
-        bottom={[0, 'unset']}
-        width="100%"
-        height={[null, '100%']}
-        maxHeight={['80vh', 'unset']}
-        opacity={isOpen ? 1 : 0}
-        style={{
-          userSelect: isOpen ? 'unset' : 'none',
-          pointerEvents: isOpen ? 'unset' : 'none',
-        }}
-      >
-        <Flex
-          flexDirection="column"
-          position="relative"
-          top={[null, '50%']}
-          transform={[null, 'translateY(-50%)']}
-          bg="white"
-          mx="auto"
-          minWidth={['100%', '396px']}
-          maxWidth={['100%', '396px']}
-          maxHeight="80vh"
-          borderRadius={['unset', '6px']}
-          boxShadow="high"
-          transition={noAnimation ? 'unset' : transition}
-        >
+      <ModalWrapper isOpen={isOpen}>
+        <ModalCardContainer ref={ref} isOpen={isOpen} noAnimation={noAnimation}>
           <Header component={HeaderComponent} />
           <Box overflowY="auto">{children}</Box>
           <Footer component={FooterComponent} />
-        </Flex>
-      </Box>
+        </ModalCardContainer>
+      </ModalWrapper>
     </>
   );
 };
@@ -115,4 +140,3 @@ export const ModalProvider: React.FC = props => {
     </ModalContext.Provider>
   );
 };
-

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -108,6 +108,32 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const { doCloseModal } = useModalState();
   const ref = React.useRef(null);
+
+  React.useEffect(() => {
+    const func = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (close) {
+          close();
+        } else {
+          doCloseModal();
+        }
+      }
+    };
+
+    if (isOpen) {
+      typeof window !== 'undefined' &&
+        window.document &&
+        window.document.createElement &&
+        document.addEventListener('keydown', func);
+    }
+    return () => {
+      typeof window !== 'undefined' &&
+        window.document &&
+        window.document.createElement &&
+        document.removeEventListener('keydown', func);
+    };
+  }, [isOpen, close]);
+
   useOnClickOutside(ref, close || doCloseModal);
 
   return (


### PR DESCRIPTION
This fixes some regressions that happened to the modal:
- The modal could sometimes live completely off screen because it was pushed below the viewport by the content of the page. The modal wrapper component had bottom: 0 that was being overwritten, or not set for some reason. Adding top=0 and left=0 fixes it
- The close by clicking outside of the modal was removed, added back in the ref to allow for that
- also cleaned up some of the wrapper components so it's easier to read as the modal will get more and more complex
- I have also implemented the ability to close the modal by hitting escape


![Screen Shot 2020-02-19 at 5 06 37 PM](https://user-images.githubusercontent.com/11803153/74885044-36c04400-533a-11ea-9e21-3105571f13a1.png)
(ignore the border on the buttons, fixed in a different PR)