### PR TITLE
Fix/input width

### DIFF
--- a/.changeset/large-cycles-hope.md
+++ b/.changeset/large-cycles-hope.md
@@ -1,0 +1,5 @@
+---
+'@stacks/ui': minor
+---
+
+This restores behavior of the Input component to default to full width.

--- a/packages/ui/src/input/index.tsx
+++ b/packages/ui/src/input/index.tsx
@@ -36,6 +36,7 @@ export const Input: React.FC<InputProps> = React.forwardRef((props, ref) => {
       aria-disabled={isDisabled}
       aria-describedby={ariaDescribedby}
       textStyle="body.small"
+      width="100%"
       style={{ WebkitAppearance: 'none', ...style }}
       {...(inputStyleProps as any)}
       {...rest}


### PR DESCRIPTION
This restores the default width of an input component to take up 100%